### PR TITLE
Documentation scratch plus some minor changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib
+numpy
+pandas>=0.23.0
+pymc3

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ REQUIRED_PACKAGES = [
 ]
 
 setup(name='pmprophet',
-      version='0.1',
+      version='0.1.1',
       description='Simplified version of the Facebook Prophet model re-implemented in PyMC3 ',
       url='https://github.com/luke14free/pm-prophet',
       author='Luca Giacomel',
       author_email='',
-      license='',
+      license='MIT',
       install_requires=REQUIRED_PACKAGES,
       packages=find_packages())


### PR DESCRIPTION
Changes:
- I added a scratch for the documentation (large parts blantly copied from the fbprophet docs),
- Fixed a minor bug (there was a `if changepoints and changepoints` check),
- added a licence (MIT is ok?),
- `fit` method now returns `self` (consistent with sklearn and fbprophet),
- I added the requirements.txt file.

Suggestions:
- Some of the methods should be re-named into "internal" format (e.g. `fit_growth` -> `_fit_growth`) or documented,
- Documentation needs improvements (I lack enough understanding of the package yet for this).