### PR TITLE
small fix for larger dataframes

### DIFF
--- a/pmprophet/model.py
+++ b/pmprophet/model.py
@@ -475,7 +475,7 @@ class PMProphet:
         m.trace = self.trace
         m.multiplicative_data = self.multiplicative_data
 
-        draws = max(self.trace[var].shape[-1] for var in self.trace.varnames if 'hat_model' not in var)
+        draws = max(self.trace[var].shape[-1] for var in self.trace.varnames if 'hat_{}'.format(self.name) not in var)
         if self.growth:
             # Start with the trend
             y_hat = m._fit_growth(prior=False)

--- a/pmprophet/model.py
+++ b/pmprophet/model.py
@@ -475,7 +475,7 @@ class PMProphet:
         m.trace = self.trace
         m.multiplicative_data = self.multiplicative_data
 
-        draws = max(self.trace[var].shape[-1] for var in self.trace.varnames)
+        draws = max(self.trace[var].shape[-1] for var in self.trace.varnames if 'hat_model' not in var)
         if self.growth:
             # Start with the trend
             y_hat = m._fit_growth(prior=False)


### PR DESCRIPTION
when the size of the dataframe becomes too large (for example if you don't run `df = df.head(180)` in the peyton_manning.ipynb example)  this max function will produce the incorrect amount of draws in `predict`. This fix gets around this problem